### PR TITLE
Fix Jest collectCoverage option name

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,6 @@
 {
   "testEnvironment": "node",
-  "collect Coverage": false,
+  "collectCoverage": false,
   "coverageDirectory": "coverage",
   "coveragePathIgnorePatterns": [
     "/node_modules/",


### PR DESCRIPTION
## Summary
- correct the Jest configuration property name to use collectCoverage

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ab61aac4832c863c59511805b0e8)