### PR TITLE
Add Dependabot security automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,69 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Mexico_City
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      prefix: deps
+    groups:
+      root-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /server
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: America/Mexico_City
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      prefix: deps-server
+    groups:
+      server-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /dashboard-app
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "09:00"
+      timezone: America/Mexico_City
+    open-pull-requests-limit: 3
+    rebase-strategy: auto
+    commit-message:
+      prefix: deps-dashboard
+    groups:
+      dashboard-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: "09:00"
+      timezone: America/Mexico_City
+    open-pull-requests-limit: 3
+    rebase-strategy: auto
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Qué cambia

- configura actualizaciones semanales de dependencias npm para la raíz, `server` y `dashboard-app`
- configura actualizaciones semanales de GitHub Actions
- agrupa actualizaciones minor y patch para reducir ruido
- limita los PR simultáneos y activa rebase automático
- distribuye los horarios en la zona `America/Mexico_City`

## Por qué

El repositorio necesita un flujo continuo y auditable para mantener dependencias y acciones actualizadas sin generar una cantidad excesiva de PR individuales.

## Impacto

Dependabot comenzará a proponer actualizaciones por cada ecosistema configurado después de que este cambio llegue a `main`. Las actualizaciones mayores permanecerán separadas para facilitar su revisión.

## Validación

- archivo validado como YAML
- formato validado con Prettier
- rutas contrastadas con los manifiestos existentes del repositorio
